### PR TITLE
Add detailed Vue interview answer library

### DIFF
--- a/vue-interview-roadmap.md
+++ b/vue-interview-roadmap.md
@@ -1,78 +1,86 @@
 # Vue Interview Roadmap (Basic → Intermediate → Advanced)
 _Last updated: 2025-09-28_
 
+> ✅ Each question now has a dedicated, in-depth answer file inside [`/vue-interview-roadmap`](./vue-interview-roadmap/). Every answer includes:
+> - A **Quick Revision** section for rapid study.
+> - A **Detailed Explanation** with terminology, comparisons, and best practices.
+> - **Code examples** illustrating the concept.
+> - A curated **Resources** list citing the references used.
+
+Use the index below as your navigation hub and progress checklist.
+
 ## 🌱 Basic Vue Questions
 **1. Vue Fundamentals**
-1.1 What are the main differences between **Vue 2 and Vue 3**?  
-1.2 Can you explain the difference between the **Options API and the Composition API**?  
-1.3 Walk me through the **Vue lifecycle hooks**. Which ones are most commonly used?  
-1.4 How does Vue’s **reactivity system** work under the hood?  
-1.5 What are the key differences between **v-if and v-show**?  
+- [1.1 What are the main differences between Vue 2 and Vue 3?](./vue-interview-roadmap/1.1-vue2-vs-vue3.md)
+- [1.2 Can you explain the difference between the Options API and the Composition API?](./vue-interview-roadmap/1.2-options-vs-composition-api.md)
+- [1.3 Walk me through the Vue lifecycle hooks. Which ones are most commonly used?](./vue-interview-roadmap/1.3-vue-lifecycle-hooks.md)
+- [1.4 How does Vue’s reactivity system work under the hood?](./vue-interview-roadmap/1.4-vue-reactivity-system.md)
+- [1.5 What are the key differences between v-if and v-show?](./vue-interview-roadmap/1.5-v-if-vs-v-show.md)
 
-**2. Directives & Components**  
-2.1 Can you explain the role of **directives** like `v-bind`, `v-model`, and `v-for`?  
-2.2 What are **Single File Components (SFCs)** and why are they useful?  
+**2. Directives & Components**
+- [2.1 Can you explain the role of directives like v-bind, v-model, and v-for?](./vue-interview-roadmap/2.1-core-directives.md)
+- [2.2 What are Single File Components (SFCs) and why are they useful?](./vue-interview-roadmap/2.2-single-file-components.md)
 
-**3. Reactivity & Forms**  
-3.1 How do **computed properties** differ from **watchers**?  
-3.2 How do you handle **forms** in Vue?  
+**3. Reactivity & Forms**
+- [3.1 How do computed properties differ from watchers?](./vue-interview-roadmap/3.1-computed-vs-watch.md)
+- [3.2 How do you handle forms in Vue?](./vue-interview-roadmap/3.2-form-handling.md)
 
 ---
 
 ## 🌿 Intermediate Vue Questions
-**4. State Management**  
-4.1 What are the basics of **Vuex** and how does it differ from local component state?  
-4.2 How do **mixins** differ from the **Composition API**?  
-4.3 Compare **Vuex with Redux**. What are their strengths and weaknesses?  
-4.4 What are some **reactivity caveats** in Vue (like array/object changes in Vue 2)?  
+**4. State Management**
+- [4.1 What are the basics of Vuex and how does it differ from local component state?](./vue-interview-roadmap/4.1-vuex-basics.md)
+- [4.2 How do mixins differ from the Composition API?](./vue-interview-roadmap/4.2-mixins-vs-composition.md)
+- [4.3 Compare Vuex with Redux. What are their strengths and weaknesses?](./vue-interview-roadmap/4.3-vuex-vs-redux.md)
+- [4.4 What are some reactivity caveats in Vue (like array/object changes in Vue 2)?](./vue-interview-roadmap/4.4-reactivity-caveats.md)
 
-**5. Routing & Navigation**  
-5.1 How do **Vue Router navigation guards** work?  
-5.2 What’s the difference between **beforeEach, beforeEnter, and beforeRouteLeave** guards?  
+**5. Routing & Navigation**
+- [5.1 How do Vue Router navigation guards work?](./vue-interview-roadmap/5.1-navigation-guards.md)
+- [5.2 What’s the difference between beforeEach, beforeEnter, and beforeRouteLeave guards?](./vue-interview-roadmap/5.2-guard-types.md)
 
-**6. Components & Composition**  
-6.1 How do you create and use **async components** in Vue?  
-6.2 What are the basics of the **Vue CLI**?  
-6.3 What is the purpose of the **setup() function in Vue 3**?  
-6.4 Can you explain **slots**, **scoped slots**, and **dynamic slots**?  
-6.5 How does **scoped CSS** work in Vue?  
-6.6 What is **Teleport in Vue 3** and when would you use it?  
-6.7 How does the **Provide/Inject API** work?  
-6.8 How can you create **custom directives** in Vue?  
+**6. Components & Composition**
+- [6.1 How do you create and use async components in Vue?](./vue-interview-roadmap/6.1-async-components.md)
+- [6.2 What are the basics of the Vue CLI?](./vue-interview-roadmap/6.2-vue-cli-basics.md)
+- [6.3 What is the purpose of the setup() function in Vue 3?](./vue-interview-roadmap/6.3-setup-function.md)
+- [6.4 Can you explain slots, scoped slots, and dynamic slots?](./vue-interview-roadmap/6.4-slots.md)
+- [6.5 How does scoped CSS work in Vue?](./vue-interview-roadmap/6.5-scoped-css.md)
+- [6.6 What is Teleport in Vue 3 and when would you use it?](./vue-interview-roadmap/6.6-teleport.md)
+- [6.7 How does the Provide/Inject API work?](./vue-interview-roadmap/6.7-provide-inject.md)
+- [6.8 How can you create custom directives in Vue?](./vue-interview-roadmap/6.8-custom-directives.md)
 
-**7. Debugging & Testing**  
-7.1 How do you handle **error boundaries** in Vue?  
-7.2 What tools does **Vue DevTools** provide for debugging?  
-7.3 What are some common **Vue testing strategies** (unit testing, integration testing, snapshot testing)?  
+**7. Debugging & Testing**
+- [7.1 How do you handle error boundaries in Vue?](./vue-interview-roadmap/7.1-error-boundaries.md)
+- [7.2 What tools does Vue DevTools provide for debugging?](./vue-interview-roadmap/7.2-vue-devtools.md)
+- [7.3 What are some common Vue testing strategies (unit testing, integration testing, snapshot testing)?](./vue-interview-roadmap/7.3-testing-strategies.md)
 
-**8. Animations & UI Enhancements**  
-8.1 How do **Vue transitions and animations** work?  
+**8. Animations & UI Enhancements**
+- [8.1 How do Vue transitions and animations work?](./vue-interview-roadmap/8.1-transitions.md)
 
 ---
 
 ## 🌳 Advanced Vue Questions
-**9. Performance & Optimization**  
-9.1 How does Vue **handle DOM updates** with its virtual DOM?  
-9.2 What are some techniques for **performance optimization in Vue apps**?  
-9.3 What are common **memory leaks in Vue** and how do you avoid them?  
+**9. Performance & Optimization**
+- [9.1 How does Vue handle DOM updates with its virtual DOM?](./vue-interview-roadmap/9.1-virtual-dom.md)
+- [9.2 What are some techniques for performance optimization in Vue apps?](./vue-interview-roadmap/9.2-performance-optimization.md)
+- [9.3 What are common memory leaks in Vue and how do you avoid them?](./vue-interview-roadmap/9.3-memory-leaks.md)
 
-**10. SSR & Ecosystem**  
-10.1 What is **Vue SSR** and how does **Nuxt.js** help with server-side rendering?  
-10.2 Explain **hydration in Vue SSR**.  
-10.3 What are the differences between **SPA, SSR, and SSG in Vue apps**?  
-10.4 How do you handle **internationalization in Vue** (**vue-i18n**)?  
+**10. SSR & Ecosystem**
+- [10.1 What is Vue SSR and how does Nuxt.js help with server-side rendering?](./vue-interview-roadmap/10.1-vue-ssr-nuxt.md)
+- [10.2 Explain hydration in Vue SSR.](./vue-interview-roadmap/10.2-hydration.md)
+- [10.3 What are the differences between SPA, SSR, and SSG in Vue apps?](./vue-interview-roadmap/10.3-spa-ssr-ssg.md)
+- [10.4 How do you handle internationalization in Vue (vue-i18n)?](./vue-interview-roadmap/10.4-internationalization.md)
 
-**11. Advanced Project Practices**  
-11.1 How do you manage **code splitting and lazy loading** in Vue?  
-11.2 What are **Composition API best practices** for scaling large projects?  
-11.3 How do you integrate **TypeScript with Vue 3**?  
-11.4 How do **suspense and async setup** work in Vue 3?  
-11.5 Explain how Vue handles **concurrent rendering** and async updates.  
-11.6 What is **tree-shaking** in Vue 3 and how does it improve performance?  
+**11. Advanced Project Practices**
+- [11.1 How do you manage code splitting and lazy loading in Vue?](./vue-interview-roadmap/11.1-code-splitting.md)
+- [11.2 What are Composition API best practices for scaling large projects?](./vue-interview-roadmap/11.2-composition-api-best-practices.md)
+- [11.3 How do you integrate TypeScript with Vue 3?](./vue-interview-roadmap/11.3-typescript-with-vue.md)
+- [11.4 How do suspense and async setup work in Vue 3?](./vue-interview-roadmap/11.4-suspense-async-setup.md)
+- [11.5 Explain how Vue handles concurrent rendering and async updates.](./vue-interview-roadmap/11.5-concurrent-rendering.md)
+- [11.6 What is tree-shaking in Vue 3 and how does it improve performance?](./vue-interview-roadmap/11.6-tree-shaking.md)
 
 ---
 
 ## ✅ Tips
-- Treat numbers as IDs (e.g., “Let’s drill into **6.3** next”).  
-- Use this file as a checklist during prep; add notes below each item.  
-- Consider splitting this into multiple files by tier if you’re building a docs site.
+- Treat numbers as IDs (e.g., “Let’s drill into **6.3** next”).
+- Mark questions as complete in your notes after reviewing their dedicated file.
+- Extend the folder with your own notes or follow-up questions to personalize your study path.

--- a/vue-interview-roadmap/1.1-vue2-vs-vue3.md
+++ b/vue-interview-roadmap/1.1-vue2-vs-vue3.md
@@ -1,0 +1,40 @@
+# 1.1 What are the main differences between Vue 2 and Vue 3?
+
+## Quick Revision
+- Vue 3 replaces the Object.defineProperty-based reactivity of Vue 2 with ES2015 Proxies, enabling deep reactivity, better performance, and tracking of property additions/deletions.
+- The Composition API augments the Options API by grouping logic by feature, improving reuse and TypeScript support.
+- Vue 3 ships a smaller runtime with tree-shaking, rewritten compiler, Fragments, Teleport, Suspense, and improved server-side rendering.
+
+## Detailed Explanation
+### Reactivity & Rendering
+Vue 2 relies on `Object.defineProperty` to convert component data into getters/setters, which cannot intercept property additions and struggles with array index changes. Vue 3 rewrites this layer using ES2015 `Proxy`, giving deep reactivity for nested structures and eliminating the need for workarounds like `Vue.set`. The virtual DOM renderer was reimplemented with a compiler-informed runtime, resulting in faster updates and support for multiple root nodes (Fragments).
+
+### APIs & TypeScript
+While Vue 2 centers on the Options API (`data`, `methods`, `computed`), Vue 3 introduces the Composition API (`setup`, `ref`, `reactive`, `computed`) so you can compose logic functions and reuse them across components. TypeScript support is first-class through better typings, script setup, and Volar integration. Migration helpers ensure Options API continues to work.
+
+### Advanced Features & Tooling
+Vue 3 adds `Teleport` for rendering elements outside component hierarchies, `Suspense` for async component loading, and better tree-shaking via ES modules. Tooling moved to Vite-based scaffolding (`create-vue`), replacing the older webpack-centric Vue CLI defaults. Server-side rendering was rebuilt on top of the new runtime for streaming and hydration improvements.
+
+## Code Example
+```vue
+<!-- Vue 3 Composition API example -->
+<script setup>
+import { ref, computed } from 'vue';
+
+const count = ref(0);
+const double = computed(() => count.value * 2);
+function increment() {
+  count.value++;
+}
+</script>
+
+<template>
+  <button @click="increment">{{ count }} → {{ double }}</button>
+</template>
+```
+The same component in Vue 2 would require the Options API and `data()`, `computed`, `methods`, illustrating the ergonomic improvements in Vue 3 for co-locating related logic.
+
+## Resources
+- [Vue.js Docs – Migration from Vue 2 to Vue 3](https://v3-migration.vuejs.org/) – official migration guide outlining runtime changes and new APIs.
+- [Vue.js Docs – Composition API](https://vuejs.org/guide/extras/composition-api-faq.html) – explains benefits over Options API with examples.
+- [Vue RFC 0042 – Function-based API](https://github.com/vuejs/rfcs/pull/42) – design rationale behind the Composition API and Proxy-based reactivity.

--- a/vue-interview-roadmap/1.2-options-vs-composition-api.md
+++ b/vue-interview-roadmap/1.2-options-vs-composition-api.md
@@ -1,0 +1,52 @@
+# 1.2 Can you explain the difference between the Options API and the Composition API?
+
+## Quick Revision
+- Options API organizes component logic by option (`data`, `methods`, `computed`), which can scatter related functionality across sections.
+- Composition API uses the `setup()` function with `ref`, `reactive`, and composables to group logic by feature and improve reuse.
+- Composition API unlocks better TypeScript inference, logic extraction, and sharing without mixins, while Options API remains simpler for small components.
+
+## Detailed Explanation
+### Options API Characteristics
+In the Options API, you declare component state and behavior inside a configuration object. Vue merges options at runtime, providing clear lifecycle hooks (`created`, `mounted`) and automatic `this` binding. This approach is approachable and works well for small components. However, as components grow, related logic (e.g., authentication) ends up split between `data`, `computed`, `watch`, and `methods`, making refactoring and reuse harder.
+
+### Composition API Characteristics
+The Composition API exposes a `setup(props, context)` function that runs before component creation. You create reactive state with `ref` or `reactive`, derive values with `computed`, and expose features by returning them. Logic can be extracted to plain functions (composables) that return reactive primitives, avoiding the global namespace collisions of mixins. Types are easier to express, and code splitting by feature improves readability.
+
+### Choosing Between Them
+Use the Options API for smaller components or teams that prefer declarative structure. Choose Composition API when you need to reuse logic, share stateful utilities, or leverage advanced TypeScript. Both APIs can coexist, and the `<script setup>` SFC syntax reduces boilerplate for Composition API code.
+
+## Code Example
+```vue
+<!-- Options API -->
+<script>
+export default {
+  data() {
+    return { count: 0 };
+  },
+  computed: {
+    double() {
+      return this.count * 2;
+    },
+  },
+  methods: {
+    increment() {
+      this.count++;
+    },
+  },
+};
+</script>
+
+<!-- Composition API with <script setup> -->
+<script setup>
+import { ref, computed } from 'vue';
+
+const count = ref(0);
+const double = computed(() => count.value * 2);
+const increment = () => count.value++;
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Options API](https://vuejs.org/guide/introduction.html#the-options-api) – official overview of the Options syntax.
+- [Vue.js Docs – Composition API](https://vuejs.org/guide/introduction.html#the-composition-api) – introduces setup and composables with examples.
+- [Vue.js Docs – Reusability with Composables](https://vuejs.org/guide/reusability/composables.html) – demonstrates logic extraction patterns unique to the Composition API.

--- a/vue-interview-roadmap/1.3-vue-lifecycle-hooks.md
+++ b/vue-interview-roadmap/1.3-vue-lifecycle-hooks.md
@@ -1,0 +1,52 @@
+# 1.3 Walk me through the Vue lifecycle hooks. Which ones are most commonly used?
+
+## Quick Revision
+- Lifecycle hooks fire during component creation, mounting, updating, and unmounting.
+- Common hooks: `onMounted`/`mounted` for DOM access, `onBeforeUnmount`/`beforeDestroy` for cleanup, `onUpdated`/`updated` for reacting to DOM updates.
+- Vue 3 exposes lifecycle hooks inside `setup()` via `onX` helpers (e.g., `onMounted`), maintaining parity with Options API equivalents.
+
+## Detailed Explanation
+### Creation Phase
+In Vue 2 Options API, `beforeCreate` and `created` run before the component is mounted. `created` is often used for initial data fetching because reactivity is ready but the DOM is not. In Vue 3 Composition API, this logic typically lives directly in `setup()`.
+
+### Mounting Phase
+`beforeMount` executes right before the initial render. `mounted` (or `onMounted` in Composition API) runs after the component’s template has been rendered and inserted into the DOM. It is ideal for interacting with DOM APIs, third-party libraries, or measurements.
+
+### Update Phase
+When reactive state changes, `beforeUpdate` triggers before the DOM patch, while `updated` fires after the DOM is updated. Use `watch` or computed props for most state reactions; reserve `updated` for DOM-dependent side effects.
+
+### Unmounting Phase
+`beforeUnmount` (`beforeDestroy` in Vue 2) runs before the component is removed. `unmounted` (`destroyed`) executes after teardown. They are crucial for removing event listeners, canceling network requests, or cleaning intervals. In Composition API, use `onBeforeUnmount` and `onUnmounted` helpers.
+
+### Error Handling & Suspense
+Vue 2.5+ adds `errorCaptured` to catch errors from child components. Vue 3 also exposes `onErrorCaptured`. Suspense components provide `onServerPrefetch` for SSR data fetching. Keep cleanup in `onBeforeUnmount` to avoid leaks.
+
+## Code Example
+```vue
+<script setup>
+import { onMounted, onBeforeUnmount, ref } from 'vue';
+
+const width = ref(window.innerWidth);
+
+function updateWidth() {
+  width.value = window.innerWidth;
+}
+
+onMounted(() => {
+  window.addEventListener('resize', updateWidth);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateWidth);
+});
+</script>
+
+<template>
+  <p>Viewport width: {{ width }}px</p>
+</template>
+```
+
+## Resources
+- [Vue.js Docs – Lifecycle Diagram](https://vuejs.org/guide/essentials/lifecycle.html) – official overview of lifecycle phases and hooks.
+- [Vue.js Docs – Composition API Lifecycle Hooks](https://vuejs.org/guide/essentials/lifecycle.html#lifecycle-hooks) – explains `onMounted`, `onUpdated`, etc.
+- [Vue.js Docs – Handling Errors](https://vuejs.org/guide/best-practices/handling-errors.html) – covers `errorCaptured` and error boundaries.

--- a/vue-interview-roadmap/1.4-vue-reactivity-system.md
+++ b/vue-interview-roadmap/1.4-vue-reactivity-system.md
@@ -1,0 +1,35 @@
+# 1.4 How does Vue’s reactivity system work under the hood?
+
+## Quick Revision
+- Vue 2 uses getters/setters via `Object.defineProperty`, while Vue 3 uses ES2015 Proxies to intercept operations.
+- Reactive getters collect dependencies (effects) in a global stack; setters trigger those effects to re-run.
+- Vue tracks dependencies per property using `Dep`/`effect` structures and scheduler queues updates to batch DOM patches.
+
+## Detailed Explanation
+### Dependency Tracking
+When a component renders, Vue evaluates reactive properties inside a watcher/effect. The currently executing effect is pushed onto a stack. The getter for each accessed property adds that effect to its dependency map (a `Dep` in Vue 2 or a `ReactiveEffect` set in Vue 3). This establishes a many-to-many relationship between state fields and render/update functions.
+
+### Change Detection & Scheduling
+When reactive data mutates, the setter notifies all collected effects. Instead of running immediately, effects are queued and flushed asynchronously (next microtask) to batch updates, avoiding redundant re-renders. Computed properties wrap their getter in a lazy effect that caches results until dependencies change.
+
+### Vue 2 vs Vue 3 Implementation
+Vue 2 creates a `Observer` per object that converts properties with getters/setters, requiring helpers (`Vue.set`, `Vue.delete`) for new properties. Vue 3 proxies the entire object, allowing detection of property addition, deletion, and iteration (`for...in`, `Object.keys`). Reactive flags (`track`, `trigger`) classify operations (GET, SET, DELETE, ITERATE) to target the right effect sets. Ref values wrap primitives and expose a `.value` getter/setter using the same machinery.
+
+## Code Example
+```js
+import { reactive, effect } from '@vue/reactivity';
+
+const state = reactive({ count: 0 });
+
+effect(() => {
+  console.log(`Count is ${state.count}`);
+});
+
+state.count++; // triggers the effect, logging "Count is 1"
+```
+The `effect` function registers a reactive effect that subscribes to `state.count`. When `count` changes, Vue schedules the effect to run again.
+
+## Resources
+- [Vue.js Docs – Reactivity Fundamentals](https://vuejs.org/guide/extras/reactivity-in-depth.html) – deep dive into the Proxy-based system.
+- [Vue.js Source – Reactivity Core](https://github.com/vuejs/core/tree/main/packages/reactivity) – reference implementation of `reactive`, `ref`, and `effect`.
+- [Vue.js Docs – Computed and Watch](https://vuejs.org/guide/essentials/computed.html) – explains lazy evaluation and dependency tracking with computed properties.

--- a/vue-interview-roadmap/1.5-v-if-vs-v-show.md
+++ b/vue-interview-roadmap/1.5-v-if-vs-v-show.md
@@ -1,0 +1,38 @@
+# 1.5 What are the key differences between v-if and v-show?
+
+## Quick Revision
+- `v-if` conditionally renders elements, adding/removing them from the DOM; `v-show` toggles the `display` CSS property.
+- `v-if` has higher toggle cost but no initial render cost when false; `v-show` always renders once but toggles cheaply.
+- Use `v-if` for infrequent conditional content (e.g., modal), `v-show` for frequent toggling (e.g., tabs).
+
+## Detailed Explanation
+### Rendering Behavior
+`v-if` controls whether Vue creates or destroys a component subtree. When the condition is false, Vue removes listeners, child components, and DOM nodes. This saves initial work when the condition is rarely true but incurs a cost each toggle. `v-show` renders the element once and simply sets `display: none` when false, preserving the DOM structure and component state.
+
+### Performance Considerations
+`v-if` lazily evaluates the branch, so expensive components are skipped entirely until needed. However, toggling often can hurt performance due to repeated mounting/unmounting. `v-show` guarantees a one-time render cost and constant-time toggling, ideal for frequently shown/hidden elements where initial render cost is acceptable.
+
+### Side Effects & Accessibility
+Because `v-show` keeps elements in the DOM, focus, component state, and watchers remain active even when hidden—useful for cached forms but potentially problematic for accessibility if hidden elements remain focusable. With `v-if`, watchers and child lifecycle hooks fire each time the branch is toggled.
+
+## Code Example
+```vue
+<template>
+  <button @click="show = !show">Toggle</button>
+
+  <HeavyChart v-if="show" />
+  <p v-show="show">This text toggles display only.</p>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import HeavyChart from './HeavyChart.vue';
+
+const show = ref(false);
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Conditional Rendering](https://vuejs.org/guide/essentials/conditional.html) – official explanation of `v-if` and `v-show` differences.
+- [Vue.js Style Guide – Avoid v-if with v-for](https://vuejs.org/style-guide/rules-essential.html#avoid-v-if-with-v-for) – related performance considerations.
+- [Vue School – Vue Conditional Rendering Guide](https://vueschool.io/articles/vuejs-tutorials/conditional-rendering-in-vue-js-3/) – practical tips on when to use each directive.

--- a/vue-interview-roadmap/10.1-vue-ssr-nuxt.md
+++ b/vue-interview-roadmap/10.1-vue-ssr-nuxt.md
@@ -1,0 +1,32 @@
+# 10.1 What is Vue SSR and how does Nuxt.js help with server-side rendering?
+
+## Quick Revision
+- Vue SSR renders components to HTML on the server, improving perceived performance and SEO.
+- The Vue SSR API (`@vue/server-renderer`) turns Vue apps into server-rendered HTML with hydration on the client.
+- Nuxt.js provides a higher-level framework for SSR/SSG, handling routing, data fetching, and deployment optimizations.
+
+## Detailed Explanation
+### Vue SSR Basics
+Server-side rendering involves running Vue components on the server to produce HTML, sending it to the client, and hydrating it with client-side JavaScript. Vue’s SSR renderer serializes the app tree with current state. Hydration attaches event listeners and reuses DOM instead of re-rendering.
+
+### Challenges & Solutions
+SSR requires handling async data fetching, managing per-request state, and ensuring deterministic output. You must avoid browser-only APIs during server render. Caching rendered pages and streaming can improve performance.
+
+### Nuxt.js Advantages
+Nuxt builds on Vue SSR by providing file-based routing, data fetching hooks (`asyncData`, `useFetch`), automatic code splitting, and deployment presets (SSR, SSG, Hybrid). It abstracts SSR boilerplate, offers modules (auth, i18n), and optimizes bundling via Nitro server.
+
+## Code Example
+```js
+// server.js
+import { createSSRApp } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import App from './App.vue';
+
+const app = createSSRApp(App);
+const html = await renderToString(app);
+```
+
+## Resources
+- [Vue.js Docs – Server-Side Rendering](https://vuejs.org/guide/scaling-up/ssr.html) – official SSR guide.
+- [Nuxt 3 Documentation](https://nuxt.com/docs) – features for SSR, SSG, and hybrid rendering.
+- [Vue SSR Guide – Hydration](https://vuejs.org/guide/scaling-up/ssr.html#client-hydration) – explains hydration lifecycle.

--- a/vue-interview-roadmap/10.2-hydration.md
+++ b/vue-interview-roadmap/10.2-hydration.md
@@ -1,0 +1,35 @@
+# 10.2 Explain hydration in Vue SSR.
+
+## Quick Revision
+- Hydration attaches Vue’s runtime to server-rendered HTML, reusing markup instead of re-rendering from scratch.
+- Vue compares server-rendered DOM with client-side virtual DOM; mismatches trigger warnings and full re-render of the subtree.
+- Proper hydration requires deterministic markup and avoiding browser-only APIs during server rendering.
+
+## Detailed Explanation
+### Hydration Flow
+After SSR sends HTML, the client downloads the JavaScript bundle. Vue creates a virtual DOM tree and walks the existing DOM to attach event listeners and reactive bindings. As long as the DOM matches expectations, Vue reuses nodes, leading to fast interactive startup.
+
+### Handling Mismatches
+If server and client render different DOM (e.g., using `Date.now()`), Vue logs hydration mismatch warnings and falls back to client rendering for that subtree. Use deterministic data, or gate browser-only logic behind `onMounted` or `process.client` checks in Nuxt.
+
+### Streaming & Suspense
+Vue 3 SSR supports streaming and Suspense, which delay hydration for async components until data resolves. On the client, hydration occurs when the async content is available, ensuring consistent markup.
+
+## Code Example
+```js
+// SSR entry
+export async function render(url) {
+  const app = createApp(App);
+  const html = await renderToString(app);
+  return html;
+}
+
+// Client entry
+const app = createApp(App);
+app.mount('#app'); // hydrates existing markup
+```
+
+## Resources
+- [Vue.js Docs – Hydration](https://vuejs.org/guide/scaling-up/ssr.html#client-hydration) – official explanation of hydration process.
+- [Nuxt 3 Docs – Rendering](https://nuxt.com/docs/guide/concepts/rendering) – describes hydration in hybrid rendering.
+- [Vue SSR Guide – Mismatch Handling](https://vuejs.org/guide/scaling-up/ssr.html#hydration-mismatch) – how Vue resolves DOM mismatches.

--- a/vue-interview-roadmap/10.3-spa-ssr-ssg.md
+++ b/vue-interview-roadmap/10.3-spa-ssr-ssg.md
@@ -1,0 +1,29 @@
+# 10.3 What are the differences between SPA, SSR, and SSG in Vue apps?
+
+## Quick Revision
+- SPA (Single Page Application) renders entirely on the client after initial bundle load; fastest builds but slower first render.
+- SSR (Server-Side Rendering) renders HTML per request on the server, improving first paint and SEO with dynamic content.
+- SSG (Static Site Generation) pre-renders pages at build time, serving static HTML with optional hydration for interactivity.
+
+## Detailed Explanation
+### SPA
+Traditional Vue CLI or Vite setups build an SPA. The server sends a minimal HTML shell and a JavaScript bundle. Pros: simple deployment, dynamic interactivity. Cons: blank initial screen until JS loads, less SEO-friendly unless content is rendered client-side after fetch.
+
+### SSR
+SSR generates HTML on demand using server runtime (Node, Nitro). Pros include better Time to First Byte (TTFB), SEO, and social sharing metadata. Cons: increased server complexity, higher infrastructure cost, need to handle per-request state and caching.
+
+### SSG
+SSG builds HTML at compile time (Nuxt `nuxi generate`). Pros: CDN-friendly, low runtime cost, fast initial render. Cons: limited to content known at build time; dynamic data requires client fetching or incremental regeneration.
+
+## Code Example
+```bash
+# Nuxt 3 rendering modes
+nuxi dev        # hybrid (SSR during dev)
+nuxi build      # produces server bundle for SSR
+nuxi generate   # outputs static site (SSG)
+```
+
+## Resources
+- [Nuxt 3 Docs – Rendering Modes](https://nuxt.com/docs/guide/concepts/rendering) – explains SPA, SSR, SSG, and hybrid.
+- [Vue.js Docs – SSR vs SSG](https://vuejs.org/guide/scaling-up/ssr.html#ssr-vs-ssg) – trade-offs overview.
+- [Vercel Blog – Understanding Rendering Strategies](https://vercel.com/blog/introducing-vercel-functions#rendering-strategies) – broader context for deployment decisions.

--- a/vue-interview-roadmap/10.4-internationalization.md
+++ b/vue-interview-roadmap/10.4-internationalization.md
@@ -1,0 +1,48 @@
+# 10.4 How do you handle internationalization in Vue (vue-i18n)?
+
+## Quick Revision
+- `vue-i18n` manages translations, locale switching, pluralization, and message formatting.
+- Configure the i18n plugin with locale messages and use the `$t` function or `useI18n` composable in components.
+- Support lazy-loaded locales, number/date formatting, and fallback locales for missing keys.
+
+## Detailed Explanation
+### Setup
+Install `vue-i18n`, create an i18n instance with messages, and register it on the app. Define fallback locales and message structure (nested objects). Use JSON, YAML, or lazy-loaded message files for larger apps.
+
+### Usage in Components
+In Options API, call `this.$t('greeting')`; in Composition API, use `const { t, locale } = useI18n()`. For dynamic parameters, pass objects (`t('invite', { name })`). Pluralization uses ICU syntax (`{count, plural, one {# item} other {# items}}`).
+
+### Advanced Features
+Lazy load locales via dynamic imports to reduce bundle size. Use `datetimeFormats` and `numberFormats` for localization. Manage locale persistence via cookies/localStorage. Combine with `vue-router` to localize routes.
+
+## Code Example
+```js
+// i18n.js
+import { createI18n } from 'vue-i18n';
+
+export const i18n = createI18n({
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: {
+    en: { hello: 'Hello {name}!' },
+    fr: { hello: 'Bonjour {name} !' },
+  },
+});
+```
+```vue
+<script setup>
+import { useI18n } from 'vue-i18n';
+
+const { t, locale } = useI18n();
+</script>
+
+<template>
+  <p>{{ t('hello', { name: 'Chloé' }) }}</p>
+  <button @click="locale.value = locale.value === 'en' ? 'fr' : 'en'">Switch</button>
+</template>
+```
+
+## Resources
+- [vue-i18n Documentation](https://vue-i18n.intlify.dev/) – plugin setup, ICU syntax, formatting.
+- [Intlify Guide – Lazy Loading](https://vue-i18n.intlify.dev/guide/advanced/lazy.html) – loading locales on demand.
+- [Nuxt i18n Module](https://i18n.nuxtjs.org/) – integration for Nuxt-based apps with routing.

--- a/vue-interview-roadmap/11.1-code-splitting.md
+++ b/vue-interview-roadmap/11.1-code-splitting.md
@@ -1,0 +1,31 @@
+# 11.1 How do you manage code splitting and lazy loading in Vue?
+
+## Quick Revision
+- Use dynamic imports and async components to load code on demand, reducing initial bundle size.
+- Vue Router supports lazy loading via route-level dynamic imports and prefetching strategies.
+- Analyze bundles with tools (Vite `--mode analyze`, webpack-bundle-analyzer) and group chunks intelligently.
+
+## Detailed Explanation
+### Dynamic Imports
+`import('./Component.vue')` returns a promise that bundlers split into separate chunks. Combined with `defineAsyncComponent`, components load only when needed. Use webpack magic comments (`/* webpackChunkName: "group-admin" */`) or Vite’s `?inline`/`?raw` modifiers to control bundling.
+
+### Routing Integration
+For routes, define `component: () => import('./views/Admin.vue')`. Vue Router loads the chunk when the route is visited. Pair with route-level guards or `Suspense` for loading indicators. Prefetch critical routes using `<link rel="prefetch">` or service workers.
+
+### Optimization
+Group related components to avoid excessive chunking. Monitor bundle sizes with analyzers and configure cache-busting filenames. For shared dependencies, let bundler extract vendor chunks. Consider dynamic `import.meta.glob` in Vite for auto-generated routes.
+
+## Code Example
+```js
+const routes = [
+  {
+    path: '/reports',
+    component: () => import(/* webpackChunkName: "reports" */ './views/Reports.vue'),
+  },
+];
+```
+
+## Resources
+- [Vue.js Docs – Async Components](https://vuejs.org/guide/components/async.html) – covers dynamic imports and Suspense.
+- [Vue Router Docs – Lazy Loading](https://router.vuejs.org/guide/advanced/lazy-loading.html) – route-level code splitting.
+- [Vite Guide – Dynamic Imports](https://vitejs.dev/guide/features.html#dynamic-import) – bundling behavior and glob imports.

--- a/vue-interview-roadmap/11.2-composition-api-best-practices.md
+++ b/vue-interview-roadmap/11.2-composition-api-best-practices.md
@@ -1,0 +1,42 @@
+# 11.2 What are Composition API best practices for scaling large projects?
+
+## Quick Revision
+- Organize logic into composables with clear naming, documented inputs/outputs, and unit tests.
+- Use TypeScript with explicit return types and interfaces to maintain contracts.
+- Maintain folder conventions (e.g., `composables/`, `stores/`) and avoid global singletons unless necessary.
+
+## Detailed Explanation
+### Composable Design
+Create focused composables that handle one concern (e.g., `useAuth`, `useForm`). Accept parameters to avoid hidden dependencies and return refs/reactive objects with descriptive property names. Document expected lifecycle usage (e.g., requires setup inside components).
+
+### Type Safety & Reusability
+Adopt TypeScript or JSDoc to describe composable interfaces. Return readonly refs when exposing derived state to prevent external mutation. Use `provide`/`inject` or Pinia for shared state rather than global variables. Compose smaller composables to build complex features.
+
+### Project Structure & Testing
+Group composables under `src/composables` and create index files if necessary. Write unit tests with Vitest to validate edge cases. Track dependencies between composables to prevent circular imports. Use linting rules (eslint-plugin-vue) and naming conventions (`useX`) for discoverability.
+
+## Code Example
+```ts
+// useAuth.ts
+import { ref, computed } from 'vue';
+
+export function useAuth(api) {
+  const user = ref(null);
+  const loading = ref(false);
+
+  async function login(credentials) {
+    loading.value = true;
+    user.value = await api.login(credentials);
+    loading.value = false;
+  }
+
+  const isAuthenticated = computed(() => !!user.value);
+
+  return { user, loading, login, isAuthenticated };
+}
+```
+
+## Resources
+- [Vue.js Docs – Composables](https://vuejs.org/guide/reusability/composables.html#write-idiomatic-composables) – best practices and naming conventions.
+- [Pinia Documentation](https://pinia.vuejs.org/introduction.html) – complements Composition API for shared state.
+- [VueUse Source](https://github.com/vueuse/vueuse) – reference for well-structured community composables.

--- a/vue-interview-roadmap/11.3-typescript-with-vue.md
+++ b/vue-interview-roadmap/11.3-typescript-with-vue.md
@@ -1,0 +1,33 @@
+# 11.3 How do you integrate TypeScript with Vue 3?
+
+## Quick Revision
+- Use the official `vue-tsc` tooling, `<script lang="ts">`, and Volar extension for type checking and IDE support.
+- Define component props/emits with `defineProps`/`defineEmits` generics or `PropType` to leverage static typing.
+- Configure build tooling (Vite, Vue CLI) to run `vue-tsc --noEmit` and integrate ESLint with TypeScript rules.
+
+## Detailed Explanation
+### Project Setup
+Scaffold with `npm create vue@latest` and choose TypeScript, or add TypeScript to existing projects by installing `typescript`, `vue-tsc`, and `@tsconfig`. Configure `tsconfig.json` for strict mode and include `.vue` files via shim declarations (`env.d.ts`).
+
+### Typing Components
+In `<script setup lang="ts">`, declare props using `const props = defineProps<{ msg: string }>()`. Use `defineEmits<{ (e: 'submit', value: string): void }>()` for event typing. For Options API, use `defineComponent` with generics. Global components and plugins can augment module declarations for typing.
+
+### Tooling & Checks
+Run `vue-tsc --noEmit` during CI for template and script type checking. Use ESLint with `@typescript-eslint` plugin. Prefer Volar over Vetur for Vue 3 TypeScript support. Handle third-party libraries with type definitions or `declare module` shims.
+
+## Code Example
+```vue
+<script setup lang="ts">
+const props = defineProps<{ count: number }>();
+const emit = defineEmits<{ (e: 'update:count', value: number): void }>();
+
+function increment() {
+  emit('update:count', props.count + 1);
+}
+</script>
+```
+
+## Resources
+- [Vue.js Docs – TypeScript Support](https://vuejs.org/guide/typescript/overview.html) – official setup and patterns.
+- [Volar Extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) – IDE support for TypeScript in Vue.
+- [vue-tsc Documentation](https://github.com/vuejs/language-tools/tree/master/packages/vue-tsc) – CLI for type checking SFCs.

--- a/vue-interview-roadmap/11.4-suspense-async-setup.md
+++ b/vue-interview-roadmap/11.4-suspense-async-setup.md
@@ -1,0 +1,45 @@
+# 11.4 How do suspense and async setup work in Vue 3?
+
+## Quick Revision
+- `Suspense` waits for async dependencies (async setup, async components) before rendering, showing fallback content meanwhile.
+- `setup()` can be `async` or return a promise; Vue suspends rendering until it resolves.
+- Use Suspense for data fetching, lazy loading, and coordinating multiple async tasks with error handling.
+
+## Detailed Explanation
+### Async setup()
+When `setup()` is marked `async` or returns a promise, Vue treats the component as async. It waits for the promise to resolve, providing resolved data to the template. During SSR, async setup ensures data is ready before rendering HTML.
+
+### Suspense Component
+Wrap async components in `<Suspense>`. The default slot renders once all async dependencies resolve; the fallback slot renders while pending. Use the `onResolve` and `onFallback` events to react to state changes. Suspense works with nested async components.
+
+### Error Handling
+If async setup throws, the error propagates to error boundaries (`onErrorCaptured`). Combine Suspense with `<template #error>` via libraries or custom wrappers to show error UI. Avoid long-running async operations blocking UI; use timeouts or streaming for better UX.
+
+## Code Example
+```vue
+<template>
+  <Suspense>
+    <template #default>
+      <AsyncProfile />
+    </template>
+    <template #fallback>
+      <p>Loading profile…</p>
+    </template>
+  </Suspense>
+</template>
+```
+```vue
+<script setup>
+import { ref } from 'vue';
+
+const profile = ref(null);
+
+const data = await fetch('/api/profile').then((res) => res.json());
+profile.value = data;
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Suspense](https://vuejs.org/guide/built-ins/suspense.html) – usage patterns and limitations.
+- [Vue.js Docs – Async setup](https://vuejs.org/guide/components/async.html#async-setup) – explains async setup semantics.
+- [Vue SSR Guide – Suspense](https://vuejs.org/guide/scaling-up/ssr.html#suspense) – SSR considerations for async components.

--- a/vue-interview-roadmap/11.5-concurrent-rendering.md
+++ b/vue-interview-roadmap/11.5-concurrent-rendering.md
@@ -1,0 +1,31 @@
+# 11.5 Explain how Vue handles concurrent rendering and async updates.
+
+## Quick Revision
+- Vue 3 uses a job queue and microtask scheduling to batch reactive updates, preventing unnecessary renders.
+- Suspense and async components allow Vue to pause rendering while awaiting promises, but Vue does not implement React-style concurrent mode.
+- `nextTick` and scheduler APIs let you coordinate DOM updates after Vue flushes the queue.
+
+## Detailed Explanation
+### Scheduler & Job Queue
+When reactive state changes, Vue queues effect jobs and flushes them asynchronously (microtasks). Multiple state changes within the same tick collapse into one render. Vue prioritizes component updates over user-created jobs, ensuring consistent UI.
+
+### Async Components & Suspense
+Async setup and Suspense introduce controlled async rendering: Vue can delay rendering a branch until promises resolve, showing fallback content. However, Vue still renders synchronously once data is ready; it doesn’t interrupt rendering mid-way like React concurrent mode.
+
+### nextTick & Custom Scheduling
+`nextTick` allows waiting for Vue’s DOM updates before running code. Advanced users can provide a custom scheduler when creating effects to integrate with requestAnimationFrame. Libraries like VueUse offer throttled/debounced refs to manage async update patterns.
+
+## Code Example
+```js
+import { ref, nextTick } from 'vue';
+
+const count = ref(0);
+count.value++;
+await nextTick();
+console.log(document.querySelector('#count').textContent);
+```
+
+## Resources
+- [Vue.js Docs – Reactivity in Depth](https://vuejs.org/guide/extras/reactivity-in-depth.html#effect-scheduler) – explains the scheduler and job queue.
+- [Vue.js Docs – nextTick](https://vuejs.org/api/general.html#nexttick) – usage patterns for post-update logic.
+- [Evan You – State of Vue 3 (VueConf)](https://www.youtube.com/watch?v=YrxBCBibVo0) – discussion on Vue’s async update strategy vs React concurrent mode.

--- a/vue-interview-roadmap/11.6-tree-shaking.md
+++ b/vue-interview-roadmap/11.6-tree-shaking.md
@@ -1,0 +1,30 @@
+# 11.6 What is tree-shaking in Vue 3 and how does it improve performance?
+
+## Quick Revision
+- Tree-shaking removes unused code from the bundle during build, reducing payload size.
+- Vue 3’s modular architecture exposes ES modules so bundlers can drop unused APIs (`ref`, `watch`, etc.).
+- Combine tree-shaking with component-level code splitting and proper imports to minimize shipped code.
+
+## Detailed Explanation
+### Modular Core
+Vue 3 reorganized the core into packages (`@vue/runtime-core`, `@vue/reactivity`, etc.) with named exports. When you import only what you need, bundlers (Rollup, esbuild) can statically analyze imports and eliminate unused exports.
+
+### Best Practices
+Avoid importing the entire Vue object (`import Vue from 'vue'`). Instead, use named imports (`import { ref } from 'vue'`). Ensure bundler config is in production mode with minification and dead-code elimination enabled. For libraries, offer ESM builds with side-effect-free modules to enable tree-shaking.
+
+### Impact
+Smaller bundles mean faster load times and better performance. Tree-shaking also enables partial builds (e.g., using only the reactivity package without the DOM runtime). Combined with `vite` or Rollup, Vue apps benefit from significant size reductions compared to Vue 2 builds.
+
+## Code Example
+```js
+// Good: tree-shakable
+import { createApp, ref } from 'vue';
+
+// Bad: prevents tree-shaking in some bundlers
+// import * as Vue from 'vue';
+```
+
+## Resources
+- [Vue.js Docs – Tree-shaking Support](https://vuejs.org/guide/extras/ways-of-using-vue.html#bundler-build) – notes on ESM builds and bundlers.
+- [Vite Documentation – Dependency Pre-Bundling](https://vitejs.dev/guide/dep-pre-bundling.html) – how Vite handles tree-shaking.
+- [Rollup Tree-Shaking Guide](https://rollupjs.org/introduction/#tree-shaking) – underlying concepts used by Vue tooling.

--- a/vue-interview-roadmap/2.1-core-directives.md
+++ b/vue-interview-roadmap/2.1-core-directives.md
@@ -1,0 +1,43 @@
+# 2.1 Can you explain the role of directives like v-bind, v-model, and v-for?
+
+## Quick Revision
+- `v-bind` dynamically binds attributes/props to reactive expressions, often shortened as `:`.
+- `v-model` creates two-way bindings by combining `:value` and `@update` semantics for inputs and custom components.
+- `v-for` renders lists by iterating over arrays/objects; always provide a unique `key` for efficient updates.
+
+## Detailed Explanation
+### v-bind
+`v-bind` keeps HTML attributes or component props in sync with reactive state. You can bind to classes (`:class`), styles (`:style`), and even pass entire attribute objects with `v-bind="object"`. On components, Vue validates props and triggers updates when bound values change.
+
+### v-model
+`v-model` is syntactic sugar that pairs `:modelValue` (or `value` on native inputs) with an `@update:modelValue` event. For native inputs it listens to `input` events; custom components must emit the `update:modelValue` event (or customize via `modelModifiers`/arguments). Modifiers like `.trim`, `.number`, and `.lazy` adjust update behavior.
+
+### v-for
+`v-for="item in items"` duplicates template blocks for each list entry. Vue reuses DOM nodes by tracking each item’s `key`. Without stable keys, Vue falls back to index-based reuse, which can lead to rendering bugs. For objects, the syntax `v-for="(value, key, index) in object"` exposes additional context. Combine with `v-if` cautiously to avoid performance issues.
+
+## Code Example
+```vue
+<template>
+  <input v-model.trim="form.email" placeholder="Email" />
+  <ul>
+    <li v-for="user in users" :key="user.id">
+      <span :class="{ online: user.online }">{{ user.name }}</span>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { reactive } from 'vue';
+
+const form = reactive({ email: '' });
+const users = reactive([
+  { id: 1, name: 'Lea', online: true },
+  { id: 2, name: 'Kai', online: false },
+]);
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Class and Style Bindings](https://vuejs.org/guide/essentials/class-and-style.html) – advanced `v-bind` usage.
+- [Vue.js Docs – Form Input Bindings](https://vuejs.org/guide/essentials/forms.html) – details on `v-model`, modifiers, and custom components.
+- [Vue.js Docs – List Rendering](https://vuejs.org/guide/essentials/list.html) – best practices for `v-for`, keys, and performance.

--- a/vue-interview-roadmap/2.2-single-file-components.md
+++ b/vue-interview-roadmap/2.2-single-file-components.md
@@ -1,0 +1,45 @@
+# 2.2 What are Single File Components (SFCs) and why are they useful?
+
+## Quick Revision
+- SFCs (`.vue` files) encapsulate template, script, and style in a single file with scoped tooling support.
+- They enable build-time compilation, hot module replacement, scoped CSS, and TypeScript integration.
+- `<script setup>` and `<style scoped>` features streamline Composition API usage and style encapsulation.
+
+## Detailed Explanation
+### Structure & Tooling
+An SFC contains `<template>`, `<script>` (or `<script setup>`), and `<style>` blocks processed by the Vue compiler. During build, the template is compiled into render functions, enabling static analysis (e.g., template type-checking with Volar). Tooling like Vite or Vue CLI understands SFC syntax for hot updates and tree-shaking.
+
+### Encapsulation & Reuse
+SFCs co-locate markup, logic, and styles, improving maintainability. `<style scoped>` transforms CSS selectors with attribute hashes to avoid leakage. You can define multiple style blocks (e.g., module, scoped, or preprocessor languages like SCSS). Custom blocks (e.g., `<docs>`, `<i18n>`) can be processed by loaders.
+
+### Advanced Features
+`<script setup>` compiles to a component definition, removing boilerplate for imports and returning values. `<script lang="ts">` enables TypeScript. `<template>` can use compile-time macros (e.g., defineProps). SFCs integrate with testing tools (Vue Test Utils) and design systems by packaging reusable components.
+
+## Code Example
+```vue
+<template>
+  <button class="primary" @click="emit('click')">
+    <slot>Submit</slot>
+  </button>
+</template>
+
+<script setup>
+const emit = defineEmits(['click']);
+</script>
+
+<style scoped>
+.primary {
+  background: #42b883;
+  border: none;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+</style>
+```
+
+## Resources
+- [Vue.js Docs – Single File Components](https://vuejs.org/guide/scaling-up/sfc.html) – official overview and compilation pipeline.
+- [Vue.js Docs – `<script setup>`](https://vuejs.org/api/sfc-script-setup.html) – syntax sugar for Composition API in SFCs.
+- [Vue.js Docs – Scoped Styles](https://vuejs.org/api/sfc-css-features.html#scoped-css) – explains style scoping and CSS modules in SFCs.

--- a/vue-interview-roadmap/3.1-computed-vs-watch.md
+++ b/vue-interview-roadmap/3.1-computed-vs-watch.md
@@ -1,0 +1,40 @@
+# 3.1 How do computed properties differ from watchers?
+
+## Quick Revision
+- Computed properties derive reactive values with caching; they re-evaluate only when dependencies change.
+- Watchers run side effects in response to reactive changes, ideal for async work or imperative tasks.
+- Prefer computed properties for declarative data transformations; use watchers for effects requiring callbacks.
+
+## Detailed Explanation
+### Computed Properties
+A computed property wraps a getter function in a lazy effect. Vue tracks dependencies during evaluation and caches the result until dependencies change. Computed props can be read like data in templates and are ideal for derived state, complex calculations, and chaining with other computed values. Writable computed props define both `get` and `set`.
+
+### Watchers
+`watch(source, callback)` observes one or more reactive sources (refs, getters, arrays) and executes a callback when they change. Watchers expose the new and previous value, support `immediate` execution, and can be flushed `post`, `pre`, or `sync`. `watchEffect` runs a reactive effect immediately and re-runs whenever dependencies change, making it great for concise side effects.
+
+### Choosing the Right Tool
+Computed props should remain pure and free of side effects, ensuring templates stay declarative. Watchers are necessary when you need to respond to changes with asynchronous logic, manual DOM interaction, or integration with external APIs. Avoid watchers for trivial transformations that could be computed props.
+
+## Code Example
+```vue
+<script setup>
+import { ref, computed, watch } from 'vue';
+
+const first = ref('Ada');
+const last = ref('Lovelace');
+const fullName = computed(() => `${first.value} ${last.value}`);
+
+watch(fullName, (newName, oldName) => {
+  console.log(`Name changed from ${oldName} to ${newName}`);
+});
+</script>
+
+<template>
+  <p>{{ fullName }}</p>
+</template>
+```
+
+## Resources
+- [Vue.js Docs – Computed Properties](https://vuejs.org/guide/essentials/computed.html) – explains caching behavior and writable computed props.
+- [Vue.js Docs – Watchers](https://vuejs.org/guide/essentials/watchers.html) – details `watch`, `watchEffect`, and configuration options.
+- [Vue.js Docs – Reactivity in Depth](https://vuejs.org/guide/extras/reactivity-in-depth.html#effects) – covers how computed and watch share effect scheduling.

--- a/vue-interview-roadmap/3.2-form-handling.md
+++ b/vue-interview-roadmap/3.2-form-handling.md
@@ -1,0 +1,72 @@
+# 3.2 How do you handle forms in Vue?
+
+## Quick Revision
+- Use `v-model` for two-way binding on inputs, modifiers for formatting, and custom components for reusable form fields.
+- Manage validation with computed rules, watchers, or libraries like Vuelidate, vee-validate, or custom composables.
+- Handle submissions by preventing default events, performing async operations, and providing UX feedback (loading, errors).
+
+## Detailed Explanation
+### Basic Binding
+Vue’s `v-model` syncs input value with reactive state. For checkboxes/radios, use bound arrays or values. Modifiers such as `.lazy` update on `change` events, `.trim` removes whitespace, and `.number` casts to numbers.
+
+### Validation Strategies
+Lightweight validation can use computed properties that return error messages and watchers to trigger asynchronous checks. More complex forms benefit from composables that centralize validation logic (`useForm`, `useField`). Popular libraries provide schema-based validation, error collections, and integration with async validators.
+
+### Submission Flow
+Handle `@submit.prevent` to stop default browser behavior. Use `async` functions to send requests, set loading states, and reset forms on success. Provide accessible feedback by disabling buttons during submission and announcing errors.
+
+## Code Example
+```vue
+<template>
+  <form @submit.prevent="submit">
+    <label>
+      Email
+      <input v-model.trim="form.email" type="email" />
+    </label>
+    <span v-if="errors.email">{{ errors.email }}</span>
+
+    <label>
+      Password
+      <input v-model="form.password" type="password" />
+    </label>
+    <span v-if="errors.password">{{ errors.password }}</span>
+
+    <button type="submit" :disabled="loading">{{ loading ? 'Signing in…' : 'Sign in' }}</button>
+  </form>
+</template>
+
+<script setup>
+import { reactive, computed, ref } from 'vue';
+
+const form = reactive({ email: '', password: '' });
+const loading = ref(false);
+const errors = reactive({ email: '', password: '' });
+
+const isValid = computed(() => {
+  errors.email = form.email.includes('@') ? '' : 'Email must contain @';
+  errors.password = form.password.length >= 8 ? '' : 'Password too short';
+  return !errors.email && !errors.password;
+});
+
+async function submit() {
+  if (!isValid.value) return;
+  loading.value = true;
+  try {
+    await fakeAuth(form);
+  } catch (err) {
+    errors.password = 'Authentication failed';
+  } finally {
+    loading.value = false;
+  }
+}
+
+function fakeAuth({ email }) {
+  return new Promise((resolve) => setTimeout(resolve, 600));
+}
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Form Input Bindings](https://vuejs.org/guide/essentials/forms.html) – explains `v-model` for each input type.
+- [vee-validate Documentation](https://vee-validate.logaretm.com/v4/) – schema-based validation for Vue 3.
+- [VueUse – useForm/useField Composables](https://vueuse.org/core/useform/) – utility composables for managing forms and validation.

--- a/vue-interview-roadmap/4.1-vuex-basics.md
+++ b/vue-interview-roadmap/4.1-vuex-basics.md
@@ -1,0 +1,44 @@
+# 4.1 What are the basics of Vuex and how does it differ from local component state?
+
+## Quick Revision
+- Vuex provides a centralized store with state, getters, mutations, and actions for predictable state management across components.
+- Local component state is encapsulated within a component; Vuex enables global sharing, time-travel debugging, and devtools integration.
+- Vuex enforces unidirectional data flow: components dispatch actions → actions commit mutations → mutations synchronously update state.
+
+## Detailed Explanation
+### Core Concepts
+Vuex organizes global state in a single store. `state` is the reactive data source, `getters` derive computed values, `mutations` are synchronous operations that change state, and `actions` handle asynchronous logic before committing mutations. Modules allow namespacing.
+
+### Differences from Local State
+Local component state suits UI-specific data that doesn’t need to be shared. When multiple components need consistent state (e.g., authentication, cart), Vuex centralizes logic, reduces prop drilling, and makes mutations traceable. Vue Devtools records mutation history for debugging and supports time travel.
+
+### Workflow & Best Practices
+Components access state via `useStore()` or helpers like `mapState`. They dispatch actions instead of committing mutations directly to keep asynchronous effects centralized. Mutations must be synchronous to keep devtools logs deterministic. Use modules to segment domains and enable lazy-loaded modules for code splitting.
+
+## Code Example
+```js
+// store/index.js
+import { createStore } from 'vuex';
+
+export default createStore({
+  state: () => ({ count: 0 }),
+  getters: {
+    double: (state) => state.count * 2,
+  },
+  mutations: {
+    increment(state) {
+      state.count++;
+    },
+  },
+  actions: {
+    asyncIncrement({ commit }) {
+      setTimeout(() => commit('increment'), 300);
+    },
+  },
+});
+```
+
+## Resources
+- [Vuex 4 Official Documentation](https://vuex.vuejs.org/) – covers state, getters, mutations, actions, and modules.
+- [Vue.js Docs – State Management](https://vuejs.org/guide/scaling-up/state-management.html) – explains when to choose Vuex vs local state or Pinia.
+- [Vue Devtools Guide](https://devtools.vuejs.org/guide/vuex.html) – demonstrates time-travel debugging and mutation inspection.

--- a/vue-interview-roadmap/4.2-mixins-vs-composition.md
+++ b/vue-interview-roadmap/4.2-mixins-vs-composition.md
@@ -1,0 +1,43 @@
+# 4.2 How do mixins differ from the Composition API?
+
+## Quick Revision
+- Mixins merge properties into components, risking namespace collisions and unclear data flow.
+- Composition API uses functions (composables) that return reactive values, offering explicit imports and reusable logic without merging.
+- Composition API improves TypeScript support, tree-shaking, and traceability compared with mixins.
+
+## Detailed Explanation
+### Mixins
+Mixins are reusable option objects whose properties merge into the component. Conflicts are resolved with merge strategies (methods override, data merged). While convenient, mixins hide dependencies, make tracing origins harder, and can cause naming collisions. Multiple mixins can lead to tight coupling and implicit behavior.
+
+### Composition API
+Composables are plain functions called inside `setup()` that return reactive state and functions. Dependencies are explicit via imports, and returned values are destructured intentionally, eliminating collisions. You can parameterize composables, share reactive instances, and manage lifecycle hooks inside them.
+
+### Migration Considerations
+In Vue 3, mixins are still supported but discouraged for large-scale reuse. Converting to composables enhances tree-shaking and TypeScript type inference, since the returned values are typed. Devtools also show composable traces, making debugging easier.
+
+## Code Example
+```js
+// useMouse.js composable
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+export function useMouse() {
+  const x = ref(0);
+  const y = ref(0);
+
+  function update(event) {
+    x.value = event.pageX;
+    y.value = event.pageY;
+  }
+
+  onMounted(() => window.addEventListener('mousemove', update));
+  onBeforeUnmount(() => window.removeEventListener('mousemove', update));
+
+  return { x, y };
+}
+```
+Compared with a mixin, `useMouse` exposes its API explicitly and avoids merging lifecycle hooks implicitly.
+
+## Resources
+- [Vue.js Docs – Mixins](https://vuejs.org/guide/reusability/mixins.html) – explains limitations and migration advice.
+- [Vue.js Docs – Composables](https://vuejs.org/guide/reusability/composables.html) – demonstrates Composition API reuse patterns.
+- [Vue RFC – Function-based API](https://github.com/vuejs/rfcs/pull/42) – motivation for replacing mixins with composables.

--- a/vue-interview-roadmap/4.3-vuex-vs-redux.md
+++ b/vue-interview-roadmap/4.3-vuex-vs-redux.md
@@ -1,0 +1,35 @@
+# 4.3 Compare Vuex with Redux. What are their strengths and weaknesses?
+
+## Quick Revision
+- Vuex is tightly integrated with Vue reactivity and mutations; Redux is framework-agnostic and uses pure reducers.
+- Vuex mutations are synchronous, tracked by devtools, and leverage Vue’s reactivity for updates; Redux reducers return new immutable state objects.
+- Vuex is simpler for Vue projects with modules/getters; Redux offers middleware ecosystem and explicit immutability but requires more boilerplate.
+
+## Detailed Explanation
+### Architecture
+Vuex organizes state with mutations and actions. Mutations directly mutate state, and Vue’s reactivity detects changes. Actions handle async logic. Redux enforces pure reducers that accept `(state, action)` and return new state objects; immutability is required for change detection. Dispatching is asynchronous but reducers are synchronous.
+
+### Tooling & Ecosystem
+Vuex integrates with Vue Devtools, supporting time-travel debugging and module inspection. It leverages Vue’s plugin system and is configured once. Redux has a large middleware ecosystem (e.g., Redux Thunk, Redux Saga) and developer tools that integrate across frameworks. However, Redux typically requires more boilerplate for actions, reducers, and selectors.
+
+### When to Choose
+For Vue-centric applications, Vuex offers first-class support, minimal boilerplate, and direct compatibility with Composition API (`useStore`). Redux is valuable when sharing state logic across multiple frameworks or when you need advanced middleware patterns. Pinia (Vue’s next-gen store) combines strengths of both by embracing Composition API and TypeScript.
+
+## Code Example
+```js
+// Redux-style reducer
+function counter(state = { count: 0 }, action) {
+  switch (action.type) {
+    case 'increment':
+      return { count: state.count + 1 };
+    default:
+      return state;
+  }
+}
+```
+Contrast with Vuex mutations that mutate state directly, relying on Vue’s reactive tracking instead of returning new objects.
+
+## Resources
+- [Vuex vs Redux Comparison – Vue Docs](https://vuex.vuejs.org/#what-about-redux) – official note on differences.
+- [Redux Documentation](https://redux.js.org/introduction/getting-started) – explains core principles and immutability.
+- [Pinia Docs – Why Not Vuex](https://pinia.vuejs.org/introduction.html#comparison-with-vuex) – context for newer state solutions influenced by Redux patterns.

--- a/vue-interview-roadmap/4.4-reactivity-caveats.md
+++ b/vue-interview-roadmap/4.4-reactivity-caveats.md
@@ -1,0 +1,33 @@
+# 4.4 What are some reactivity caveats in Vue (like array/object changes in Vue 2)?
+
+## Quick Revision
+- Vue 2 cannot detect property addition/deletion or index-based array mutations without helpers; Vue 3 resolves this with Proxies.
+- Use `Vue.set`/`this.$set` and `Vue.delete` in Vue 2 to ensure new properties are reactive, or array methods like `splice`.
+- In Vue 3, prefer `reactive`/`ref` and avoid mutating raw objects returned from `toRaw`; use `markRaw` for opt-outs.
+
+## Detailed Explanation
+### Vue 2 Limitations
+Because Vue 2 proxies each property using `Object.defineProperty`, it can’t intercept property additions. Adding `obj.newProp = 1` won’t trigger updates. Similarly, setting `arr[index] = value` won’t be reactive. Use `Vue.set(obj, 'newProp', value)` or `this.$set` to define reactive getters/setters. For arrays, prefer methods like `splice`, `push`, or `shift`, which Vue intercepts.
+
+### Vue 3 Improvements
+Vue 3’s Proxy-based system tracks operations like `set`, `deleteProperty`, and `has`. Property additions and deletions are reactive. However, some caveats remain: using `toRaw` to bypass reactivity requires manual updates, and storing non-reactive libraries might need `markRaw` to prevent deep proxying. When destructuring reactive objects, you may lose reactivity unless you convert to refs (`toRefs`).
+
+### Best Practices
+Avoid mutating reactive objects outside Vue’s reactivity (e.g., by reassigning `state = newObj` inside `setup`). For arrays, rely on `push`, `splice`, or `arr[index] = value` (works in Vue 3). In Vue 2 legacy projects, document usage of `Vue.set` and avoid replacing entire reactive objects without using `Object.assign` to keep references.
+
+## Code Example
+```js
+// Vue 2 example
+data() {
+  return { user: { name: 'Evan' }, tags: ['vue'] };
+},
+mounted() {
+  this.$set(this.user, 'role', 'maintainer'); // reactive addition
+  this.tags.splice(1, 0, 'frontend');
+}
+```
+
+## Resources
+- [Vue 2 Docs – Reactivity Caveats](https://v2.vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats) – legacy guidance on arrays/objects.
+- [Vue 3 Docs – Reactivity in Depth](https://vuejs.org/guide/extras/reactivity-in-depth.html) – explains Proxy traps and caveats.
+- [Vue.js Docs – toRef and toRefs](https://vuejs.org/api/reactivity-utilities.html#toref) – avoiding reactivity loss when destructuring.

--- a/vue-interview-roadmap/5.1-navigation-guards.md
+++ b/vue-interview-roadmap/5.1-navigation-guards.md
@@ -1,0 +1,32 @@
+# 5.1 How do Vue Router navigation guards work?
+
+## Quick Revision
+- Navigation guards are hooks that execute during route changes, allowing auth checks, redirects, or data fetching.
+- Guards exist globally (`beforeEach`, `beforeResolve`, `afterEach`), per-route (`beforeEnter`), and in-component (`beforeRouteEnter`, etc.).
+- Guards must call `next()` (Vue Router 3) or return values/promises (Vue Router 4) to control navigation flow.
+
+## Detailed Explanation
+### Guard Lifecycle
+When navigating, Vue Router evaluates guards in order: leaving guards (`beforeRouteLeave`), global `beforeEach`, per-route `beforeEnter`, in-component `beforeRouteEnter`, and finally `beforeResolve`. After the navigation is confirmed, `afterEach` runs. Guards can cancel, redirect, or allow navigation.
+
+### Vue Router 4 Syntax
+In Vue Router 4 (Vue 3), guards can return `false` (cancel), a route location (redirect), or a promise. Asynchronous guards can `await` operations. You no longer call `next()`; returning suffices (though `next` still works for compatibility). Guards receive `to`, `from`, and a `next` callback.
+
+### Use Cases
+Common uses include authentication (redirect to login if not authorized), fetching data before entering a route, analytics tracking, or confirming unsaved changes. Combine guards with meta fields (e.g., `meta.requiresAuth`) to centralize logic.
+
+## Code Example
+```js
+// router.js
+router.beforeEach(async (to, from) => {
+  if (to.meta.requiresAuth && !(await isAuthenticated())) {
+    return { name: 'login', query: { redirect: to.fullPath } };
+  }
+  // returning nothing continues navigation
+});
+```
+
+## Resources
+- [Vue Router Docs – Navigation Guards](https://router.vuejs.org/guide/advanced/navigation-guards.html) – full lifecycle explanation.
+- [Vue Router Docs – Meta Fields](https://router.vuejs.org/guide/advanced/meta.html) – using meta info with guards.
+- [Vue Router Docs – Composition API](https://router.vuejs.org/guide/advanced/composition-api.html) – using guards with composition utilities like `onBeforeRouteUpdate`.

--- a/vue-interview-roadmap/5.2-guard-types.md
+++ b/vue-interview-roadmap/5.2-guard-types.md
@@ -1,0 +1,50 @@
+# 5.2 What’s the difference between beforeEach, beforeEnter, and beforeRouteLeave guards?
+
+## Quick Revision
+- `beforeEach` is a global guard that runs on every navigation, ideal for app-wide checks like authentication.
+- `beforeEnter` is defined per-route and runs only when entering that specific route (not on component updates).
+- `beforeRouteLeave` is an in-component guard that runs when leaving the current route, often used for unsaved-change prompts.
+
+## Detailed Explanation
+### Global Guard: beforeEach
+Registered on the router instance, `beforeEach` receives `to`/`from` and runs before every navigation, including redirects. Use it for logic that applies universally, such as verifying auth meta fields or logging page views. In Vue Router 4, return `false` to cancel or a route object to redirect.
+
+### Route-Specific Guard: beforeEnter
+Configured directly in a route record, `beforeEnter` executes when navigating into that route for the first time or via redirects, but not on query/param updates when the component is reused. This guard is great for fetching route-specific data or validating route params before component creation.
+
+### In-Component Guard: beforeRouteLeave
+Defined within component options or via Composition API (`onBeforeRouteLeave`), this guard runs when navigation is leaving the component’s route. It can prevent navigation if there are unsaved changes. Because it has access to component instance state, it can read forms or unsaved drafts.
+
+## Code Example
+```js
+// router.js
+const routes = [
+  {
+    path: '/admin',
+    component: () => import('./AdminDashboard.vue'),
+    beforeEnter: (to, from) => {
+      if (!hasRole('admin')) return { name: 'forbidden' };
+    },
+  },
+];
+
+router.beforeEach((to) => {
+  if (to.meta.requiresAuth && !isLoggedIn()) return { name: 'login' };
+});
+```
+```js
+// In a component
+import { onBeforeRouteLeave } from 'vue-router';
+
+onBeforeRouteLeave((to, from, next) => {
+  if (formHasUnsavedChanges()) {
+    const leave = window.confirm('Discard changes?');
+    if (!leave) return false;
+  }
+});
+```
+
+## Resources
+- [Vue Router Docs – Global Guards](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards) – usage of `beforeEach`.
+- [Vue Router Docs – Per-Route Guards](https://router.vuejs.org/guide/advanced/navigation-guards.html#per-route-guards) – explains `beforeEnter` behavior.
+- [Vue Router Docs – In-Component Guards](https://router.vuejs.org/guide/advanced/navigation-guards.html#in-component-guards) – details `beforeRouteLeave` and Composition API equivalents.

--- a/vue-interview-roadmap/6.1-async-components.md
+++ b/vue-interview-roadmap/6.1-async-components.md
@@ -1,0 +1,45 @@
+# 6.1 How do you create and use async components in Vue?
+
+## Quick Revision
+- Async components defer loading of component code until needed, reducing initial bundle size.
+- Use `defineAsyncComponent` (Vue 3) or dynamic imports with `defineAsyncComponent(() => import('./Foo.vue'))`.
+- Provide loading/error components and timeouts for better UX when lazy loading.
+
+## Detailed Explanation
+### Defining Async Components
+In Vue 3, import `defineAsyncComponent` and pass a loader function that returns a promise. The component resolves when the promise fulfills. In templates, async components behave like normal components; Vue handles the promise internally.
+
+### Advanced Options
+`defineAsyncComponent` accepts an options object allowing `loader`, `loadingComponent`, `errorComponent`, `delay`, and `timeout`. This lets you show skeletons or fallbacks while fetching the component. Combine with dynamic routing or conditional rendering to load on demand.
+
+### Usage Patterns
+Async components pair well with code-splitting via bundlers (Vite/Webpack). They work with Suspense in Vue 3, enabling placeholder templates until async components resolve. For route-level code splitting, use dynamic imports in Vue Router’s route records.
+
+## Code Example
+```js
+import { defineAsyncComponent } from 'vue';
+
+export const AsyncChart = defineAsyncComponent({
+  loader: () => import('./Chart.vue'),
+  loadingComponent: () => import('./ChartSkeleton.vue'),
+  delay: 200,
+  timeout: 5000,
+});
+```
+```vue
+<template>
+  <Suspense>
+    <template #default>
+      <AsyncChart />
+    </template>
+    <template #fallback>
+      <p>Loading chart…</p>
+    </template>
+  </Suspense>
+</template>
+```
+
+## Resources
+- [Vue.js Docs – Async Components](https://vuejs.org/guide/components/async.html) – official usage patterns and options.
+- [Vue.js Docs – Suspense](https://vuejs.org/guide/built-ins/suspense.html) – integrating async components with fallback UI.
+- [Vite Docs – Code Splitting](https://vitejs.dev/guide/features.html#dynamic-import) – explains how dynamic imports produce separate chunks.

--- a/vue-interview-roadmap/6.2-vue-cli-basics.md
+++ b/vue-interview-roadmap/6.2-vue-cli-basics.md
@@ -1,0 +1,29 @@
+# 6.2 What are the basics of the Vue CLI?
+
+## Quick Revision
+- Vue CLI (now in maintenance) scaffolds Vue 2/3 projects with webpack-based build tooling and plugin system.
+- It offers interactive project creation, zero-config defaults, and extensibility through CLI plugins (TypeScript, Vuex, Router).
+- Modern projects often use Vite or `create-vue`, but Vue CLI remains relevant for legacy webpack workflows.
+
+## Detailed Explanation
+### Project Creation
+Running `vue create my-app` launches an interactive prompt to select presets (default, TypeScript, Router, Vuex, Linter). Presets store configuration in `package.json` for reuse. Vue CLI installs dependencies and sets up webpack, Babel, PostCSS, and optional features.
+
+### Development & Build
+`npm run serve` starts a dev server with hot module replacement, while `npm run build` outputs optimized bundles using webpack. Vue CLI exposes configuration via `vue.config.js`, allowing chainable webpack adjustments, dev server proxies, and environment variables through `.env` files.
+
+### Plugin Ecosystem
+`vue add` installs official or community plugins that extend the webpack config (e.g., PWA, Apollo, ESLint). While Vue CLI is now in maintenance, understanding it helps maintain existing codebases and migrate to newer tooling like Vite.
+
+## Code Example
+```bash
+npm install -g @vue/cli
+vue create dashboard
+cd dashboard
+npm run serve
+```
+
+## Resources
+- [Vue CLI Documentation](https://cli.vuejs.org/) – official guide and configuration reference.
+- [Vue CLI 5 Release Notes](https://github.com/vuejs/vue-cli/releases/tag/v5.0.0) – highlights current maintenance status.
+- [Vue Docs – Tooling Guide](https://vuejs.org/guide/scaling-up/tooling.html) – compares Vue CLI with Vite and `create-vue`.

--- a/vue-interview-roadmap/6.3-setup-function.md
+++ b/vue-interview-roadmap/6.3-setup-function.md
@@ -1,0 +1,44 @@
+# 6.3 What is the purpose of the setup() function in Vue 3?
+
+## Quick Revision
+- `setup()` is the entry point for the Composition API, running before component creation to initialize reactive state and logic.
+- It receives `props` and `context` and must return values to expose them to the template.
+- Inside `setup()`, you use Composition API features (`ref`, `reactive`, `computed`, lifecycle hooks) without `this`.
+
+## Detailed Explanation
+### Execution Timing
+`setup()` executes before the component instance is created, so `this` is undefined. Props are reactive but read-only. The function can return an object (exposed to template) or a render function. `<script setup>` compiles to a `setup()` under the hood, automatically exposing top-level bindings.
+
+### Arguments & Context
+The first argument is `props`, reactive but should not be destructured directly (use `toRefs`). The second argument is a context object with `attrs`, `slots`, and `emit`. `emit` replaces `$emit` for emitting events. `expose` allows customizing what refs are exposed to `ref` users.
+
+### Logic Organization
+Within `setup()`, you can call composables, register lifecycle hooks (`onMounted`, etc.), and create watchers. Returning state makes it accessible in the template; functions can be returned directly. This structure enables modular, testable code.
+
+## Code Example
+```vue
+<script>
+import { ref, onMounted } from 'vue';
+
+export default {
+  props: { start: { type: Number, default: 0 } },
+  setup(props, { emit }) {
+    const count = ref(props.start);
+
+    function increment() {
+      count.value++;
+      emit('update:count', count.value);
+    }
+
+    onMounted(() => console.log('Mounted with', count.value));
+
+    return { count, increment };
+  },
+};
+</script>
+```
+
+## Resources
+- [Vue.js Docs – Composition API setup](https://vuejs.org/api/composition-api-setup.html) – official reference for `setup` arguments and return values.
+- [Vue.js Docs – `<script setup>`](https://vuejs.org/api/sfc-script-setup.html) – syntactic sugar transforming into `setup()`.
+- [Vue School – Understanding setup()](https://vueschool.io/articles/vuejs-tutorials/understanding-the-setup-function-in-vue-js-3/) – tutorial with practical patterns.

--- a/vue-interview-roadmap/6.4-slots.md
+++ b/vue-interview-roadmap/6.4-slots.md
@@ -1,0 +1,59 @@
+# 6.4 Can you explain slots, scoped slots, and dynamic slots?
+
+## Quick Revision
+- Slots let parent components inject content into child components; default slots cover the basic use case.
+- Scoped slots pass data from child to parent via slot props, enabling render customization.
+- Dynamic slots allow binding slot names dynamically (`v-slot:[name]`) for flexible layouts.
+
+## Detailed Explanation
+### Default & Named Slots
+A component declares `<slot>` (default) or `<slot name="header">`. Parents provide content using `<template v-slot:header>` or shorthand `#header`. Named slots enable multiple insertion points.
+
+### Scoped Slots
+Scoped slots expose data from the child by adding props to the slot element (e.g., `<slot name="row" :item="item">`). The parent receives the props via `v-slot:row="{ item }"`. This is useful for tables, lists, and renderless components where the parent controls rendering.
+
+### Dynamic Slots
+Use `v-slot:[dynamicName]` to bind slot names computed at runtime. Combined with `<component :is>` or conditional layouts, dynamic slots allow customizing component sections without rewriting templates.
+
+## Code Example
+```vue
+<!-- DataTable.vue -->
+<template>
+  <table>
+    <thead>
+      <slot name="head">
+        <tr><th>Name</th><th>Email</th></tr>
+      </slot>
+    </thead>
+    <tbody>
+      <tr v-for="row in rows" :key="row.id">
+        <slot name="row" :row="row">
+          <td>{{ row.name }}</td>
+          <td>{{ row.email }}</td>
+        </slot>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup>
+defineProps({ rows: Array });
+</script>
+```
+```vue
+<!-- Parent -->
+<DataTable :rows="users">
+  <template #head>
+    <tr><th>User</th><th>Contact</th></tr>
+  </template>
+  <template #row="{ row }">
+    <td>{{ row.name.toUpperCase() }}</td>
+    <td><a :href="`mailto:${row.email}`">Email</a></td>
+  </template>
+</DataTable>
+```
+
+## Resources
+- [Vue.js Docs – Slots](https://vuejs.org/guide/components/slots.html) – comprehensive guide to default, named, and scoped slots.
+- [Vue.js Docs – Dynamic Slots](https://vuejs.org/guide/components/slots.html#dynamic-slot-names) – demonstrates `v-slot:[name]` syntax.
+- [Vue School – Renderless Components](https://vueschool.io/articles/vuejs-tutorials/what-are-renderless-components-in-vue-js/) – practical use cases for scoped slots.

--- a/vue-interview-roadmap/6.5-scoped-css.md
+++ b/vue-interview-roadmap/6.5-scoped-css.md
@@ -1,0 +1,38 @@
+# 6.5 How does scoped CSS work in Vue?
+
+## Quick Revision
+- `<style scoped>` in SFCs transforms selectors with unique data attributes to limit styles to the component.
+- Scoped styles apply using attribute selectors (e.g., `[data-v-123abc]`), preserving component isolation.
+- Use deep selectors (`::v-deep`) or global styles for styling child components and third-party libraries.
+
+## Detailed Explanation
+### Compilation Process
+When compiling an SFC with `<style scoped>`, Vue injects a unique attribute (e.g., `data-v-1a2b3c`) into the component’s root and child elements. CSS selectors in the scoped block are rewritten to include that attribute, ensuring they target only elements in the component.
+
+### Working with Child Components
+Scoped styles do not penetrate child components by default. To style child components, use the `::v-deep` combinator or global styles. For example, `::v-deep(.child)` applies to descendant components. Alternatively, create shared CSS modules or global stylesheets for consistent branding.
+
+### Considerations
+Scoped CSS increases specificity but doesn’t guarantee isolation from global resets. Use CSS modules (`<style module>`) for hashed class names or utility frameworks (Tailwind). Remember that scoped styles are still processed by PostCSS/Babel, so autoprefixing works.
+
+## Code Example
+```vue
+<template>
+  <div class="card">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.card {
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  border-radius: 8px;
+}
+</style>
+```
+
+## Resources
+- [Vue.js Docs – Scoped CSS](https://vuejs.org/api/sfc-css-features.html#scoped-css) – explains attribute rewriting and deep selectors.
+- [Vue.js Docs – CSS Modules](https://vuejs.org/api/sfc-css-features.html#css-modules) – alternative to scoped for module-based class names.
+- [Vue School – Scoped Styles](https://vueschool.io/lessons/scoped-styles-in-vue-js) – video lesson covering deep selectors and caveats.

--- a/vue-interview-roadmap/6.6-teleport.md
+++ b/vue-interview-roadmap/6.6-teleport.md
@@ -1,0 +1,33 @@
+# 6.6 What is Teleport in Vue 3 and when would you use it?
+
+## Quick Revision
+- `Teleport` renders component content into a different part of the DOM while preserving reactivity.
+- Use it for overlays, modals, tooltips, or portals that need to escape CSS/DOM hierarchy constraints.
+- Teleported content still belongs to the Vue component tree, so props, events, and reactivity work normally.
+
+## Detailed Explanation
+### How Teleport Works
+`<Teleport to="#modal-root">` moves its slot content to the target element elsewhere in the DOM. Vue keeps the component in the logical tree, so state and lifecycle behave as if it were inline, but the rendered DOM lives at the target location. The target can be any CSS selector or DOM node.
+
+### Use Cases
+Teleport solves z-index and overflow issues for modals or popovers by rendering them at the document root. It’s also useful for rendering inside iframes or shadow DOM hosts. Because events bubble within Vue’s virtual tree, you can emit events or access provide/inject normally.
+
+### Considerations
+Ensure the target element exists before Teleport renders; create it in HTML or mount hook. Teleport supports conditional rendering and can disable teleporting with the `disabled` prop. When server-side rendering, ensure matching structure between server and client to avoid hydration issues.
+
+## Code Example
+```vue
+<template>
+  <Teleport to="#portal">
+    <div class="modal" v-if="open">
+      <button @click="$emit('close')">Close</button>
+      <slot />
+    </div>
+  </Teleport>
+</template>
+```
+
+## Resources
+- [Vue.js Docs – Teleport](https://vuejs.org/guide/built-ins/teleport.html) – official description and usage guidelines.
+- [Vue Mastery – Using Teleport](https://www.vuemastery.com/blog/teleport-in-vue-3/) – practical scenarios and pitfalls.
+- [Vue.js Docs – SSR with Teleport](https://vuejs.org/guide/scaling-up/ssr.html#teleport) – considerations for server rendering.

--- a/vue-interview-roadmap/6.7-provide-inject.md
+++ b/vue-interview-roadmap/6.7-provide-inject.md
@@ -1,0 +1,37 @@
+# 6.7 How does the Provide/Inject API work?
+
+## Quick Revision
+- `provide` allows ancestor components to supply values; `inject` lets descendants access them without prop drilling.
+- Values are reactive when provided as refs/reactives; primitives remain static unless wrapped.
+- Use Provide/Inject for dependency injection patterns, plugin configuration, or global services.
+
+## Detailed Explanation
+### Providing Values
+Call `provide(key, value)` inside `setup()` (or use the Options API’s `provide` option) to register a value on the component instance. Keys can be strings or symbols. Provided values are available to all descendants, not just direct children.
+
+### Injecting Values
+Descendant components call `inject(key, defaultValue)` to retrieve the provided value. If the provided value is reactive (ref or reactive object), the consumer sees updates. Injected values are read-only by convention; to allow mutation, provide methods or reactive state and document usage.
+
+### Use Cases & Patterns
+Provide/Inject is great for theming, localization, or sharing service instances (e.g., a global event bus). It complements but does not replace Vuex/Pinia for large-scale state. Provide defaults when injection fails to keep components decoupled.
+
+## Code Example
+```js
+// Provider
+import { provide, ref } from 'vue';
+
+const theme = ref('light');
+provide('theme', theme);
+```
+```js
+// Consumer
+import { inject } from 'vue';
+
+const theme = inject('theme', 'light');
+```
+Changing `theme.value` in the provider updates consumers automatically.
+
+## Resources
+- [Vue.js Docs – Provide/Inject](https://vuejs.org/guide/components/provide-inject.html) – official patterns and caveats.
+- [VueUse – provideReactive](https://vueuse.org/shared/providereactive/) – helper utilities for reactive injection.
+- [Vue School – Dependency Injection in Vue 3](https://vueschool.io/articles/vuejs-tutorials/dependency-injection-in-vue-js-3/) – tutorial with common scenarios.

--- a/vue-interview-roadmap/6.8-custom-directives.md
+++ b/vue-interview-roadmap/6.8-custom-directives.md
@@ -1,0 +1,42 @@
+# 6.8 How can you create custom directives in Vue?
+
+## Quick Revision
+- Custom directives encapsulate low-level DOM manipulations outside component logic.
+- Register directives globally with `app.directive` or locally via the `directives` option / `v-node` functions in Composition API.
+- Directive hooks (`created`, `beforeMount`, `mounted`, `updated`, `unmounted`) mirror component lifecycle for DOM access.
+
+## Detailed Explanation
+### Defining Directives
+In Vue 3, a directive is an object with lifecycle hooks or a function shorthand for `mounted`/`updated`. Hooks receive the element, binding (`value`, `oldValue`, `arg`, `modifiers`), and vnode. Register globally in `main.js` with `app.directive('focus', { mounted(el) { el.focus(); } })` or locally in component options.
+
+### Use Cases
+Directives suit DOM behaviors such as autofocus, lazy loading, intersection observers, or third-party library integration. They keep components declarative while encapsulating imperative DOM work.
+
+### Composition API Integration
+You can export directives and apply them with `v-my-directive`. Inside SFCs, use the `directives` option or register globally. Avoid using directives for logic that fits better as components or composables.
+
+## Code Example
+```js
+// focus.js
+export const vFocus = {
+  mounted(el) {
+    el.focus();
+  },
+};
+```
+```js
+// main.js
+import { createApp } from 'vue';
+import App from './App.vue';
+import { vFocus } from './directives/focus';
+
+createApp(App).directive('focus', vFocus).mount('#app');
+```
+```vue
+<input v-focus />
+```
+
+## Resources
+- [Vue.js Docs – Custom Directives](https://vuejs.org/guide/reusability/custom-directives.html) – lifecycle hooks and examples.
+- [Vue School – Custom Directives Lesson](https://vueschool.io/lessons/custom-directives-in-vue-js) – practical directive patterns.
+- [MDN – Intersection Observer API](https://developer.mozilla.org/docs/Web/API/Intersection_Observer_API) – often used in custom directives for lazy loading.

--- a/vue-interview-roadmap/7.1-error-boundaries.md
+++ b/vue-interview-roadmap/7.1-error-boundaries.md
@@ -1,0 +1,41 @@
+# 7.1 How do you handle error boundaries in Vue?
+
+## Quick Revision
+- Vue uses the `errorCaptured` hook (Options API) or `onErrorCaptured` (Composition API) to catch errors from child components.
+- You can render fallback UI by returning `false` (prevent propagation) and setting local state.
+- Global error handlers (`app.config.errorHandler`) capture uncaught errors for logging.
+
+## Detailed Explanation
+### Component-Level Error Capturing
+`errorCaptured(err, instance, info)` fires when a descendant throws during render, lifecycle, or event handler. Returning `false` stops the error from bubbling further. Use this to swap in fallback UI or report telemetry. In Composition API, call `onErrorCaptured` inside `setup()`.
+
+### Global Handlers
+Set `app.config.errorHandler = (err, instance, info) => { ... }` to catch errors application-wide. Combine with logging services (Sentry) and display notifications. `app.config.warnHandler` can intercept warnings.
+
+### Async & Suspense
+For async components and Suspense, rejection errors trigger `onErrorCaptured` or the fallback slot. Wrap potentially failing code in try/catch to provide user feedback.
+
+## Code Example
+```vue
+<script setup>
+import { ref, onErrorCaptured } from 'vue';
+
+const failed = ref(false);
+
+onErrorCaptured((err) => {
+  failed.value = true;
+  console.error('Child error', err);
+  return false; // prevent further propagation
+});
+</script>
+
+<template>
+  <div v-if="failed">Something went wrong.</div>
+  <ChildComponent v-else />
+</template>
+```
+
+## Resources
+- [Vue.js Docs – Error Handling](https://vuejs.org/guide/best-practices/handling-errors.html) – explains `errorCaptured` and global handlers.
+- [Vue.js API – app.config.errorHandler](https://vuejs.org/api/application.html#app-config-errorhandler) – application-level error handling.
+- [Sentry Vue SDK](https://docs.sentry.io/platforms/javascript/guides/vue/) – practical integration for logging captured errors.

--- a/vue-interview-roadmap/7.2-vue-devtools.md
+++ b/vue-interview-roadmap/7.2-vue-devtools.md
@@ -1,0 +1,28 @@
+# 7.2 What tools does Vue DevTools provide for debugging?
+
+## Quick Revision
+- Vue DevTools inspects component hierarchies, reactive state, events, and performance metrics.
+- It offers timeline recording, Vuex/Pinia state inspection, and component re-render tracing.
+- DevTools integrates with browser extensions or standalone Electron app for local development.
+
+## Detailed Explanation
+### Component Inspector
+The Components tab displays the tree with props, emitted events, and reactive state. You can edit state directly, trigger component re-rendering, and highlight elements in the DOM. It supports both Options and Composition API (showing refs/composables).
+
+### Timeline & Performance
+The Timeline records events such as component mounts, Vuex mutations, router navigations, and custom marks. You can analyze render duration and identify slow updates. The Performance tab (beta) helps detect unnecessary re-renders.
+
+### State Management & Plugins
+Vue DevTools integrates with Vuex and Pinia, allowing time-travel debugging, mutation/action logs, and editing store state. Plugins can add custom inspectors (e.g., Apollo, Vue I18n). For SSR or remote debugging, use the standalone app or set up devtools for mobile via network connections.
+
+## Code Example
+```bash
+# Install standalone devtools for remote debugging
+npm install -g @vue/devtools
+vue-devtools
+```
+
+## Resources
+- [Vue DevTools Documentation](https://devtools.vuejs.org/) – official guide covering features and setup.
+- [Vue DevTools – Timeline Guide](https://devtools.vuejs.org/guide/timeline.html) – using the timeline to profile apps.
+- [Pinia DevTools Integration](https://pinia.vuejs.org/devtools/) – explains store inspection and debugging features.

--- a/vue-interview-roadmap/7.3-testing-strategies.md
+++ b/vue-interview-roadmap/7.3-testing-strategies.md
@@ -1,0 +1,35 @@
+# 7.3 What are some common Vue testing strategies (unit testing, integration testing, snapshot testing)?
+
+## Quick Revision
+- Unit tests isolate components/composables with tools like Vitest or Jest plus Vue Test Utils.
+- Integration tests render multiple components or routes together to verify interactions and store/router integration.
+- Snapshot tests capture rendered output for regression checks but should complement functional assertions.
+
+## Detailed Explanation
+### Unit Testing
+Use Vue Test Utils to mount components with stubbed dependencies. Test props, emitted events, computed properties, and DOM output. Vitest offers fast ESM-based runs; Jest is common in legacy setups. Mock HTTP requests and global services to isolate behavior.
+
+### Integration Testing
+Render components with their child dependencies, router, and store to verify flows like navigation or form submission. Cypress Component Testing or Playwright can render Vue components in a real browser for higher fidelity. Keep integration tests focused on critical paths to balance speed and coverage.
+
+### Snapshot Testing
+Snapshot tests compare the rendered markup against stored snapshots, catching unintended structural changes. Use sparingly and alongside targeted assertions to avoid brittle tests. Update snapshots intentionally when UI changes are expected.
+
+## Code Example
+```js
+import { mount } from '@vue/test-utils';
+import Counter from './Counter.vue';
+
+describe('Counter', () => {
+  it('increments on click', async () => {
+    const wrapper = mount(Counter);
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.text()).toContain('1');
+  });
+});
+```
+
+## Resources
+- [Vue Test Utils Documentation](https://test-utils.vuejs.org/) – API for mounting and asserting Vue components.
+- [Vitest Guide – Testing Vue](https://vitest.dev/guide/features.html#testing-vue) – configuration for Vue + Vitest.
+- [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/vue/overview) – running Vue components in Cypress for integration tests.

--- a/vue-interview-roadmap/8.1-transitions.md
+++ b/vue-interview-roadmap/8.1-transitions.md
@@ -1,0 +1,45 @@
+# 8.1 How do Vue transitions and animations work?
+
+## Quick Revision
+- Vue provides `<Transition>` and `<TransitionGroup>` components to apply CSS transitions/animations when elements enter/leave.
+- Transition hooks add/remove CSS classes (`*-enter`, `*-enter-active`, etc.) that you style with CSS or animate via JS hooks.
+- Use TransitionGroup for list animations and integrate with libraries like GSAP for advanced effects.
+
+## Detailed Explanation
+### Transition Component
+Wrap a single element or component in `<Transition name="fade">`. Vue automatically toggles classes (`fade-enter-from`, `fade-enter-active`, `fade-leave-to`) during enter/leave. You define CSS for these classes to control opacity, transforms, or other properties. `appear` enables initial render animations.
+
+### Transition Hooks
+Transition components expose JS hooks (`onBeforeEnter`, `onEnter`, `onAfterLeave`) for manual control or integrating with JS animation libraries. Provide `done` callback to signal completion when using asynchronous animations.
+
+### TransitionGroup
+`<TransitionGroup>` handles lists by tracking elements via keys, applying move transitions using the `*-move` class. It wraps elements in a `span` by default; use `tag` prop to change the wrapper.
+
+## Code Example
+```vue
+<template>
+  <button @click="show = !show">Toggle</button>
+  <Transition name="fade">
+    <p v-if="show" class="message">Hello Vue!</p>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+const show = ref(true);
+</script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>
+```
+
+## Resources
+- [Vue.js Docs – Transition Basics](https://vuejs.org/guide/built-ins/transition.html) – explains CSS class hooks and appear transitions.
+- [Vue.js Docs – TransitionGroup](https://vuejs.org/guide/built-ins/transition-group.html) – list animations and move transitions.
+- [GSAP + Vue Guide](https://greensock.com/docs/v3/Plugins/Observer) – using GSAP with Vue transitions.

--- a/vue-interview-roadmap/9.1-virtual-dom.md
+++ b/vue-interview-roadmap/9.1-virtual-dom.md
@@ -1,0 +1,34 @@
+# 9.1 How does Vue handle DOM updates with its virtual DOM?
+
+## Quick Revision
+- Vue compiles templates into render functions that produce virtual DOM (VNode) trees.
+- When reactive state changes, Vue diffs the new VNode tree against the previous tree to compute minimal DOM patches.
+- Vue’s compiler generates optimized blocks and patch flags to skip static sections and accelerate updates.
+
+## Detailed Explanation
+### Virtual DOM Rendering
+Templates compile to `render` functions returning VNodes (`h(type, props, children)`). On initial render, Vue converts VNodes to real DOM. Subsequent renders generate new VNodes which are diffed against the old ones.
+
+### Diffing Algorithm
+Vue uses a fast, optimized diffing algorithm with heuristics. It compares nodes by type and key, reusing DOM elements where possible. For lists, keys guide reordering via longest increasing subsequence (LIS) to minimize moves. Patch flags annotate dynamic parts (e.g., text, class) so Vue only updates what changed.
+
+### Compiler Optimizations
+Vue 3’s compiler detects static nodes and hoists them out of render functions, marking dynamic nodes with patch flags (e.g., `TEXT`, `CLASS`). Block tree tracking groups dynamic children for targeted updates, reducing diff cost. Fragments allow multiple root nodes without extra wrappers.
+
+## Code Example
+```js
+import { h, ref } from 'vue';
+
+export default {
+  setup() {
+    const count = ref(0);
+    return () => h('button', { onClick: () => count.value++ }, `Count: ${count.value}`);
+  },
+};
+```
+This render function creates a VNode for the button each render; Vue updates only the text content when `count` changes.
+
+## Resources
+- [Vue.js Docs – Rendering Mechanism](https://vuejs.org/guide/extras/rendering-mechanism.html) – explains virtual DOM and patching.
+- [Vue.js Docs – Template Compilation](https://vuejs.org/guide/extras/render-function.html) – shows how templates become render functions.
+- [Vue 3 Source – Renderer](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/renderer.ts) – implementation of the patch algorithm and block tree optimizations.

--- a/vue-interview-roadmap/9.2-performance-optimization.md
+++ b/vue-interview-roadmap/9.2-performance-optimization.md
@@ -1,0 +1,29 @@
+# 9.2 What are some techniques for performance optimization in Vue apps?
+
+## Quick Revision
+- Optimize rendering with computed properties, memoization, and avoiding unnecessary reactive dependencies.
+- Use lazy loading (async components, route-level code splitting) and tree-shaking to reduce bundle size.
+- Employ caching (`keep-alive`), virtualization, and performance profiling to handle heavy UI interactions.
+
+## Detailed Explanation
+### Rendering Optimizations
+Avoid expensive computations inside templates; use computed props. Limit reactive dependencies by destructuring with `toRefs` and splitting components to reduce re-render scope. Use `v-memo` (Vue 3.3+) or `shallowRef` for large objects. Leverage `defineComponent({ inheritAttrs: false })` to avoid attribute updates when unnecessary.
+
+### Network & Bundle
+Implement code splitting with dynamic imports and `defineAsyncComponent`. Tree-shake unused components by using ES module imports. Compress assets, enable HTTP/2, and leverage CDN caching. Use `preload`/`prefetch` for critical resources.
+
+### UI Techniques
+`<KeepAlive>` caches component instances between route/tab switches. Virtualize long lists with libraries like Vue Virtual Scroll List. Debounce expensive watchers, throttle scroll handlers, and use `requestAnimationFrame` for smooth animations. Profile using browser devtools and Vue DevTools performance timeline.
+
+## Code Example
+```vue
+<KeepAlive include="Dashboard">
+  <component :is="currentView" />
+</KeepAlive>
+```
+Caching the `Dashboard` component avoids re-fetching data each time the user navigates back.
+
+## Resources
+- [Vue.js Docs – Performance](https://vuejs.org/guide/best-practices/performance.html) – official performance checklist.
+- [Vue.js Docs – KeepAlive](https://vuejs.org/api/built-in-components.html#keepalive) – caching component instances.
+- [VueUse – useVirtualList](https://vueuse.org/core/usevirtuallist/) – helper for list virtualization.

--- a/vue-interview-roadmap/9.3-memory-leaks.md
+++ b/vue-interview-roadmap/9.3-memory-leaks.md
@@ -1,0 +1,34 @@
+# 9.3 What are common memory leaks in Vue and how do you avoid them?
+
+## Quick Revision
+- Memory leaks often stem from lingering event listeners, timers, or subscriptions not cleaned up on unmount.
+- Use lifecycle hooks (`onBeforeUnmount`) to remove listeners, cancel requests, and clear intervals.
+- Watch for detached DOM nodes from third-party libraries and leverage weak references or plugin teardown APIs.
+
+## Detailed Explanation
+### Sources of Leaks
+Components that attach global event listeners (`window`, `document`), websockets, or intervals can leak if not removed during teardown. Third-party libraries that imperatively manipulate the DOM may leave detached nodes. Retained references in closures can also prevent garbage collection.
+
+### Prevention
+Use `onBeforeUnmount`/`onUnmounted` to clean up listeners and timers. Wrap external subscriptions in composables that manage cleanup. For watchers, stop them manually with the returned stop handle when no longer needed. Avoid storing DOM elements or component instances in long-lived singletons.
+
+### Diagnostics
+Use browser memory profiles and heap snapshots to track retained objects. Vue DevTools performance timeline can reveal components not being destroyed. Tools like `why-did-you-render` alternatives or manual logging help detect repeated mount/unmount cycles without cleanup.
+
+## Code Example
+```js
+import { onMounted, onBeforeUnmount } from 'vue';
+
+onMounted(() => {
+  window.addEventListener('resize', handler);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handler);
+});
+```
+
+## Resources
+- [Vue.js Docs – Performance: Avoid Memory Leaks](https://vuejs.org/guide/best-practices/performance.html#avoid-memory-leaks) – official guidance on cleanup.
+- [MDN – Memory Management](https://developer.mozilla.org/docs/Web/JavaScript/Memory_Management) – fundamentals of garbage collection and leaks.
+- [Vue School – Preventing Memory Leaks](https://vueschool.io/articles/vuejs-tutorials/how-to-prevent-memory-leaks-in-vue-js-applications/) – examples of common pitfalls.


### PR DESCRIPTION
## Summary
- replace the single vue interview checklist with an index that links to per-question study guides
- add detailed markdown answers for all 40 questions, each with quick revision notes, explanations, examples, and resources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d96cbe27448323a11f0d6d0ad47cd3